### PR TITLE
array_filter doesn't reset the index to 0

### DIFF
--- a/test/GitDataTest.php
+++ b/test/GitDataTest.php
@@ -66,9 +66,9 @@ class GitDataTest extends TestCase {
         expect($remotes[0])->to->be->instanceOf(GitRemote::class);
 
         /** @var GitRemote[] $origin */
-        $origin = array_filter($remotes->getArrayCopy(), function(GitRemote $remote): bool {
+        $origin = array_values(array_filter($remotes->getArrayCopy(), function(GitRemote $remote): bool {
           return $remote->getName() == 'origin';
-        });
+        }));
 
         expect($origin)->to->have->lengthOf(1);
         expect($origin[0]->getURL())->to->equal('https://github.com/cedx/coveralls.php.git');


### PR DESCRIPTION
Tests fail when you have more than one repo paths and `origin` isn't first